### PR TITLE
RLC-2-UpdateHighliteReferencesToRyelite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ This project/package provides two things in one. A plugin-type api to use during
 ## Installation
 
 ```bash
-npm install @highlite/core
+npm install @ryelite/core
 -or-
-yarn add @highlite/core
+yarn add @ryelite/core
 ```
 
 ## Usage
 
-This package provides TypeScript type definitions for developing Highlite plugins. Import the types you need:
+This package provides TypeScript type definitions for developing Ryelite plugins. Import the types you need:
 
 ```typescript
-import { Plugin, IHighlite, PluginSettings } from '@highlite/core';
+import { Plugin, IHighlite, PluginSettings } from '@ryelite/core';
 
 export class MyPlugin extends Plugin {
     pluginName = 'MyAwesomePlugin';
@@ -46,7 +46,7 @@ export class MyPlugin extends Plugin {
 
 - `NotificationManager` - In-game notifications
 - `ItemTooltip` - Generic Tooltip Manager
-- `UIManager` - Highlite Centric way of creating on-screen UI Elements
+- `UIManager` - Ryelite Centric way of creating on-screen UI Elements
 - `PanelManager` - UI panel management
 - `SettingsManager` - Plugin settings management
 - `DatabaseManager` - Data persistence

--- a/docs/gamehooks.md
+++ b/docs/gamehooks.md
@@ -1,7 +1,7 @@
 <p><img src="https://github.com/user-attachments/assets/da5bb809-3949-4854-99e4-1619022444e7" width="128"/></p>
 
-# HighLite
-HighLite is an open-source game client for High Spell and has received permission to operate from the game developer (Dew).
+# Ryelite
+Ryelite is an open-source game client for High Spell. Currently pending official permission to operate from the game developer (Dew). Highlite, which this client is forked from, has received said permission.
 
 ---
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -42,7 +42,7 @@ export class Highlite {
     pluginDataManager: PluginDataManager;
 
     constructor() {
-        console.info('[Highlite] Core Initializing!');
+        console.info('[Ryelite] Core Initializing!');
 
         document.highlite = {
             managers: {},
@@ -67,7 +67,7 @@ export class Highlite {
     }
 
 
-    // NOTE: The login screen buttons attempt to open up in the highlite window without these.
+    // NOTE: The login screen buttons attempt to open up in the ryelite window without these.
     async loginHooks(fnName: string, ...args: any[]) {
         if (fnName === 'LoginScreen_handleRegisterButtonClicked') {
             window.open('https://highspell.com/register', '_blank');
@@ -95,7 +95,7 @@ export class Highlite {
     }
 
     async stopHook(fnName: string, ...args: any[]) {
-        console.warn(`[Highlite] Stopping all plugins due to: ${fnName}`);
+        console.warn(`[Ryelite] Stopping all plugins due to: ${fnName}`);
         this.panelManager.forceClose();
         this.settingsManager.deinit();
         this.pluginManager.stopAll();
@@ -103,7 +103,7 @@ export class Highlite {
     }
 
     initialize() {
-        console.info("[Highlite] Core Initializing")
+        console.info("[Ryelite] Core Initializing")
 
         // Bind the classes from the hook manager (registerClass)
         // Read all the found signature binding 
@@ -138,13 +138,13 @@ export class Highlite {
     }
 
     async start() {
-        console.info('[Highlite] Core Started!');
+        console.info('[Ryelite] Core Started!');
         await this.databaseManager.initDB();
         if (!this.databaseManager.database) {
-            console.error('[Highlite] Database not initialized!');
+            console.error('[Ryelite] Database not initialized!');
             return;
         } else {
-            console.info('[Highlite] Database initialized!');
+            console.info('[Ryelite] Database initialized!');
         }
         await this.notificationManager.askNotificationPermission();
     // Initialize Plugin Hub now that DB is ready
@@ -152,12 +152,12 @@ export class Highlite {
     }
 
     stop() {
-        console.info('[Highlite] Core Stopped!');
+        console.info('[Ryelite] Core Stopped!');
         this.pluginManager.stopAll();
     }
 
     reload() {
-        console.info('[Highlite] Core Reloading');
+        console.info('[Ryelite] Core Reloading');
         this.stop();
         this.start();
     }

--- a/src/interfaces/highlite/plugin/plugin.class.ts
+++ b/src/interfaces/highlite/plugin/plugin.class.ts
@@ -64,18 +64,18 @@ export abstract class Plugin {
 
     // Log seems to be broken from loading HighSpell Client
     log(...args: any[]): void {
-        console.info(`[Highlite][${this.pluginName} Plugin]`, ...args);
+        console.info(`[RyeLite][${this.pluginName} Plugin]`, ...args);
     }
 
     info(...args: any[]): void {
-        console.info(`[Highlite][${this.pluginName} Plugin]`, ...args);
+        console.info(`[RyeLite][${this.pluginName} Plugin]`, ...args);
     }
 
     warn(...args: any[]): void {
-        console.warn(`[Highlite][${this.pluginName} Plugin]`, ...args);
+        console.warn(`[RyeLite][${this.pluginName} Plugin]`, ...args);
     }
 
     error(...args: any[]): void {
-        console.error(`[Highlite][${this.pluginName} Plugin]`, ...args);
+        console.error(`[RyeLite][${this.pluginName} Plugin]`, ...args);
     }
 }

--- a/src/managers/game/contextMenuManager.ts
+++ b/src/managers/game/contextMenuManager.ts
@@ -536,7 +536,7 @@ export class ContextMenuManager {
 
         if (!classObject) {
             console.warn(
-                `[Highlite] Attempted to register unknown static client class hook (${sourceClass}).`
+                `[Ryelite] Attempted to register unknown static client class hook (${sourceClass}).`
             );
             return false;
         }

--- a/src/managers/highlite/hookManager.ts
+++ b/src/managers/highlite/hookManager.ts
@@ -39,7 +39,7 @@ export class HookManager {
 
         if (!classInstance) {
             console.warn(
-                `[Highlite] ${className} (${mappedName}) is not defined in client.`
+                `[Ryelite] ${className} (${mappedName}) is not defined in client.`
             );
             return false;
         }
@@ -79,7 +79,7 @@ export class HookManager {
 
         if (!enumInstance) {
             console.warn(
-                `[Highlite] ${enumName} (${mappedName}) is not defined in client.`
+                `[Ryelite] ${enumName} (${mappedName}) is not defined in client.`
             );
             return false;
         }
@@ -98,7 +98,7 @@ export class HookManager {
 
         if (!classObject) {
             console.warn(
-                `[Highlite] Attempted to register unknown client class hook (${sourceClass}).`
+                `[Ryelite] Attempted to register unknown client class hook (${sourceClass}).`
             );
             return false;
         }
@@ -130,7 +130,7 @@ export class HookManager {
 
         if (!classObject) {
             console.warn(
-                `[Highlite] Attempted to register unknown client class override hook (${sourceClass}).`
+                `[Ryelite] Attempted to register unknown client class override hook (${sourceClass}).`
             );
             return false;
         }
@@ -159,7 +159,7 @@ export class HookManager {
 
         if (!classObject) {
             console.warn(
-                `[Highlite] Attempted to register unknown static client class hook (${sourceClass}).`
+                `[Ryelite] Attempted to register unknown static client class hook (${sourceClass}).`
             );
             return false;
         }
@@ -182,7 +182,7 @@ export class HookManager {
 
     private hook(fnName: string, ...args: any[]): void {
         if (!document.highlite.managers.PluginManager) {
-            console.warn(`[Highlite] Plugin Manager not initialized.`);
+            console.warn(`[Ryelite] Plugin Manager not initialized.`);
             return;
         }
         for (const plugin of document.highlite.managers.PluginManager.plugins) {
@@ -196,7 +196,7 @@ export class HookManager {
                     }
                 } catch (error) {
                     console.error(
-                        `[Highlite] Error in plugin ${plugin.instance?.pluginName} (${fnName}):`,
+                        `[Ryelite] Error in plugin ${plugin.instance?.pluginName} (${fnName}):`,
                         error
                     );
                 }

--- a/src/managers/highlite/notificationManager.ts
+++ b/src/managers/highlite/notificationManager.ts
@@ -45,7 +45,7 @@ export class NotificationManager {
             return false;
         }
 
-        const notification = new Notification('Highlite', {
+        const notification = new Notification('Ryelite', {
             icon: './static/icons/icon.png',
             body: message,
         });
@@ -60,19 +60,19 @@ export class NotificationManager {
         // Check if the browser supports notifications
         if (!('Notification' in window)) {
             console.info(
-                '[Highlite] This browser does not support notifications.'
+                '[Ryelite] This browser does not support notifications.'
             );
             this.canNotify = false;
         }
 
         if (Notification.permission === 'granted') {
-            console.info('[Highlite] Notification permission granted.');
+            console.info('[Ryelite] Notification permission granted.');
             this.canNotify = true;
         } else if (Notification.permission === 'denied') {
-            console.info('[Highlite] Notification permission denied.');
+            console.info('[Ryelite] Notification permission denied.');
             this.canNotify = false;
         } else {
-            console.info('[Highlite] Notification permission dismissed.');
+            console.info('[Ryelite] Notification permission dismissed.');
             this.canNotify = false;
         }
     }

--- a/src/managers/highlite/panelManager.ts
+++ b/src/managers/highlite/panelManager.ts
@@ -81,7 +81,7 @@ export class PanelManager {
     requestMenuItem(icon: string, title: string) {
         // Verify an equivalent icon does not exist
         if (this.barContentPages[icon]) {
-            throw new Error(`[Highlite] Bar Icon ${icon} already exists`);
+            throw new Error(`[Ryelite] Bar Icon ${icon} already exists`);
         }
 
         const iconElement = document.createElement('div');
@@ -135,7 +135,7 @@ export class PanelManager {
     removeMenuItem(icon: string) {
         // Remove Icon and Content
         if (!this.barIcons[icon] || !this.barContentPages[icon]) {
-            throw new Error(`[Highlite] Bar Icon ${icon} does not exist`);
+            throw new Error(`[Ryelite] Bar Icon ${icon} does not exist`);
         }
 
         this.highliteBar?.removeChild(this.barIcons[icon]);

--- a/src/managers/highlite/settingsManager.ts
+++ b/src/managers/highlite/settingsManager.ts
@@ -1573,7 +1573,7 @@ export class SettingsManager {
                 default:
                     // Debugging for error handling
                     const settingType = (setting as any)?.type;
-                    const errorMessage = `[Highlite] Unsupported setting type for ${settingKey}. `;
+                    const errorMessage = `[Ryelite] Unsupported setting type for ${settingKey}. `;
                     const fullErrorMessage = errorMessage.concat(settingType ? `Could not read type '${settingType}'` : `Setting type does not exist.`);
                     throw new Error(fullErrorMessage);
             }

--- a/src/managers/highlite/uiManager.ts
+++ b/src/managers/highlite/uiManager.ts
@@ -85,7 +85,7 @@ export class UIManager {
                 element.classList.add('highlite-ui-client-internal');
                 if (!document.getElementById('hs-screen-mask')) {
                     throw new Error(
-                        'Highlite UI Manager: #hs-screen-mask not found'
+                        'Ryelite UI Manager: #hs-screen-mask not found'
                     );
                 } else {
                     document

--- a/src/utilities/resources.ts
+++ b/src/utilities/resources.ts
@@ -53,14 +53,14 @@ export class HighliteResources {
             openRequest.onsuccess = (event: Event) => {
                 const target = event.target as IDBOpenDBRequest;
                 this.db = target.result;
-                console.debug(`[Highlite Loader] IndexDB ${this.dbName} opened successfully.`);
+                console.debug(`[Ryelite Loader] IndexDB ${this.dbName} opened successfully.`);
                 this.initialized = true;
                 resolve(true);
             };
 
             // Handle failure
             openRequest.onerror = () => {
-                console.error(`[Highlite Loader] IndexDB ${this.dbName} could not be opened.`);
+                console.error(`[Ryelite Loader] IndexDB ${this.dbName} could not be opened.`);
                 this.db = null;
                 this.initialized = false;
                 resolve(false);
@@ -70,10 +70,10 @@ export class HighliteResources {
             openRequest.onupgradeneeded = (event: IDBVersionChangeEvent) => {
                 const target = event.target as IDBOpenDBRequest;
                 this.db = target.result;
-                console.debug(`[Highlite Loader] IndexDB ${this.dbName} was created.`);
+                console.debug(`[Ryelite Loader] IndexDB ${this.dbName} was created.`);
                 if (this.db && !this.db.objectStoreNames.contains(this.storeName)) {
                     this.db.createObjectStore(this.storeName);
-                    console.debug(`[Highlite Loader] IndexDB Object Store ${this.storeName} was created.`);
+                    console.debug(`[Ryelite Loader] IndexDB Object Store ${this.storeName} was created.`);
                 }
             };
         });
@@ -84,19 +84,19 @@ export class HighliteResources {
 
         // Guard: initialisation not complete
         if (!this.initialized) {
-            console.warn('[Highlite Loader] Attempted to setItem before the database was initialized');
+            console.warn('[Ryelite Loader] Attempted to setItem before the database was initialized');
             return false;
         }
 
         // Guard: database is null
         if (!this.db) {
-            console.warn(`[Highlite Loader] Attempted to setItem on a 'null' database`);
+            console.warn(`[Ryelite Loader] Attempted to setItem on a 'null' database`);
             return false;
         }
 
         // Guard: object store missing
         if (!this.db.objectStoreNames.contains(this.storeName)) {
-            console.error(`[Highlite Loader] Object store ${this.storeName} does not exist.`);
+            console.error(`[Ryelite Loader] Object store ${this.storeName} does not exist.`);
             return false;
         }
 
@@ -105,10 +105,10 @@ export class HighliteResources {
 
         // Debug success / failure of transaction (optional)
         transaction.oncomplete = () => {
-            console.debug(`[Highlite Loader] setItem transaction request succeeded`);
+            console.debug(`[Ryelite Loader] setItem transaction request succeeded`);
         };
         transaction.onerror = () => {
-            console.warn(`[Highlite Loader] setItem transaction request failed on ${this.storeName}`);
+            console.warn(`[Ryelite Loader] setItem transaction request failed on ${this.storeName}`);
         };
 
         // Get the object store
@@ -120,11 +120,11 @@ export class HighliteResources {
         // Return a promise representing completion
         return new Promise<boolean>((resolve) => {
             setRequest.onsuccess = () => {
-                console.debug(`[Highlite Loader] setItem set Key: ${keyName} to Value (type): ${typeof value}`);
+                console.debug(`[Ryelite Loader] setItem set Key: ${keyName} to Value (type): ${typeof value}`);
                 resolve(true);
             };
             setRequest.onerror = () => {
-                console.warn(`[Highlite Loader] setItem could not set Key: ${keyName}`);
+                console.warn(`[Ryelite Loader] setItem could not set Key: ${keyName}`);
                 resolve(false);
             };
         });
@@ -135,19 +135,19 @@ export class HighliteResources {
 
         // Guard: initialisation not complete
         if (!this.initialized) {
-            console.warn('[Highlite Loader] Attempted to getItem before the database was initialized');
+            console.warn('[Ryelite Loader] Attempted to getItem before the database was initialized');
             return null;
         }
 
         // Guard: database is null
         if (!this.db) {
-            console.warn(`[Highlite Loader] Attempted to getItem on a 'null' database`);
+            console.warn(`[Ryelite Loader] Attempted to getItem on a 'null' database`);
             return null;
         }
 
         // Guard: object store missing
         if (!this.db.objectStoreNames.contains(this.storeName)) {
-            console.error(`[Highlite Loader] Object store ${this.storeName} does not exist.`);
+            console.error(`[Ryelite Loader] Object store ${this.storeName} does not exist.`);
             return null;
         }
 
@@ -155,10 +155,10 @@ export class HighliteResources {
         const transaction = this.db.transaction(this.storeName, 'readonly');
 
         transaction.oncomplete = () => {
-            console.debug(`[Highlite Loader] getItem transaction request succeeded`);
+            console.debug(`[Ryelite Loader] getItem transaction request succeeded`);
         };
         transaction.onerror = () => {
-            console.warn(`[Highlite Loader] getItem transaction request failed on ${this.storeName}`);
+            console.warn(`[Ryelite Loader] getItem transaction request failed on ${this.storeName}`);
         };
 
         // Lookup the key
@@ -169,12 +169,12 @@ export class HighliteResources {
         return new Promise<T | null>((resolve) => {
             getRequest.onsuccess = () => {
                 console.debug(
-                    `[Highlite Loader] getItem retrieved Key: ${keyName} with Value (type): ${typeof getRequest.result}`
+                    `[Ryelite Loader] getItem retrieved Key: ${keyName} with Value (type): ${typeof getRequest.result}`
                 );
                 resolve(getRequest.result as T ?? null);
             };
             getRequest.onerror = () => {
-                console.warn(`[Highlite Loader] getItem could not retrieve Key: ${keyName}`);
+                console.warn(`[Ryelite Loader] getItem could not retrieve Key: ${keyName}`);
                 resolve(null);
             };
         });
@@ -184,11 +184,11 @@ export class HighliteResources {
     async deleteItem(keyName: string): Promise<boolean> {
 
         if (!this.initialized || !this.db) {
-            console.warn('[Highlite Loader] Attempted to deleteItem before database was ready');
+            console.warn('[Ryelite Loader] Attempted to deleteItem before database was ready');
             return false;
         }
         if (!this.db.objectStoreNames.contains(this.storeName)) {
-            console.error(`[Highlite Loader] Object store ${this.storeName} does not exist.`);
+            console.error(`[Ryelite Loader] Object store ${this.storeName} does not exist.`);
             return false;
         }
 
@@ -198,11 +198,11 @@ export class HighliteResources {
 
         return new Promise<boolean>((resolve) => {
             delReq.onsuccess = () => {
-                console.debug(`[Highlite Loader] deleteItem removed Key: ${keyName}`);
+                console.debug(`[Ryelite Loader] deleteItem removed Key: ${keyName}`);
                 resolve(true);
             };
             delReq.onerror = () => {
-                console.warn(`[Highlite Loader] deleteItem failed for Key: ${keyName}`);
+                console.warn(`[Ryelite Loader] deleteItem failed for Key: ${keyName}`);
                 resolve(false);
             };
         });
@@ -211,11 +211,11 @@ export class HighliteResources {
     // Clear the entire store
     async clear(): Promise<boolean> {
         if (!this.initialized || !this.db) {
-            console.warn('[Highlite Loader] Attempted to clear before database was ready');
+            console.warn('[Ryelite Loader] Attempted to clear before database was ready');
             return false;
         }
         if (!this.db.objectStoreNames.contains(this.storeName)) {
-            console.error(`[Highlite Loader] Object store ${this.storeName} does not exist.`);
+            console.error(`[Ryelite Loader] Object store ${this.storeName} does not exist.`);
             return false;
         }
         const tx = this.db.transaction(this.storeName, 'readwrite');
@@ -223,11 +223,11 @@ export class HighliteResources {
         const clearReq = store.clear();
         return new Promise<boolean>((resolve) => {
             clearReq.onsuccess = () => {
-                console.debug(`[Highlite Loader] clear removed all keys in ${this.storeName}`);
+                console.debug(`[Ryelite Loader] clear removed all keys in ${this.storeName}`);
                 resolve(true);
             };
             clearReq.onerror = () => {
-                console.warn(`[Highlite Loader] clear failed on ${this.storeName}`);
+                console.warn(`[Ryelite Loader] clear failed on ${this.storeName}`);
                 resolve(false);
             };
         });
@@ -239,7 +239,7 @@ export class HighliteResources {
             this.db.close();
             this.db = null;
             this.initialized = false;
-            console.debug(`[Highlite Loader] IndexDB ${this.dbName} was closed.`);
+            console.debug(`[Ryelite Loader] IndexDB ${this.dbName} was closed.`);
         }
     }
 }


### PR DESCRIPTION
Finished the "first pass" of updating all references from the "highlite.dev" website to "ryelite.org". A few things might be missed, but the very prominent stuff is updated.

Also updated informational pages such as the README. Updated any logging statements from "highlite" to "ryelite".

Didn't update the API itself -- e.g., if a function had "highlite" in the name, then we'll just live with it.